### PR TITLE
Experiment with index

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,6 @@ require_relative "./timelog"
 include Timelog
 
 class Product < ActiveRecord::Base
-
   establish_connection adapter: "sqlite3", database: "product-database.db"
 
   class << self
@@ -54,6 +53,7 @@ class Product < ActiveRecord::Base
   end
 end
 
+Product.connection.disable_query_cache!
 # This commands below is used to demonstrate the advantage of database index in Rails.
 
 # Run the migration to create products table in product-database
@@ -81,17 +81,16 @@ timelog("use OR") { puts Product.where(name: "Product 999").or(Product.where(nam
 timelog("In a range of value") { puts Product.where(serial: ["Product 999", "Product 998"]).explain }
 
 # Experiment with multiple columns query
-#
-# Without an index for name
+puts "There is only index for name, not for serial column"
 timelog("name > serial") { Product.where(name: "Product 999", serial: "P-0999-0-1").explain }
 timelog("serial > name") { Product.where(serial: "P-0999-0-1", name: "Product 999").explain }
 
 # With no index
 Product.reset!
 
+puts "There is no index"
 timelog("name > serial") { Product.where(name: "Product 999", serial: "P-0999-0-1").explain }
 timelog("serial > name") { Product.where(serial: "P-0999-0-1", name: "Product 999").explain }
-
 
 # With Index for name and serial
 Product.reset!

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require "active_record"
+require_relative "./timelog"
 
 class Product < ActiveRecord::Base
   establish_connection adapter: "sqlite3", database: "product-database.db"

--- a/app.rb
+++ b/app.rb
@@ -1,53 +1,56 @@
 require "active_record"
 require_relative "./timelog"
 
+include Timelog
+
 class Product < ActiveRecord::Base
+
   establish_connection adapter: "sqlite3", database: "product-database.db"
 
-  def self.migrate!(with_sample_data: true, sample_data_size: 1000)
-    unless connection.table_exists?(table_name)
-      connection.create_table table_name do |t|
-        t.string :serial
-        t.string :name
-        t.timestamp
+  class << self
+    def migrate!(with_sample_data: true, sample_data_size: 1000)
+      unless connection.table_exists?(table_name)
+        connection.create_table table_name do |t|
+          t.string :serial
+          t.string :name
+          t.timestamp
+        end
+
+        sample_data(sample_data_size) if with_sample_data
       end
-
-      sample_data(sample_data_size) if with_sample_data
     end
-  end
 
-  def self.display
-    printf "%-5s%-20s%-20s\n" % %w[Id Serial Name]
-    all.each do |product|
-      printf "%-5d%-20s%-20s\n" % [ product.id, product.serial, product.name ]
+    def display
+      printf "%-5s%-20s%-20s\n" % %w[Id Serial Name]
+      all.each do |product|
+        printf "%-5d%-20s%-20s\n" % [ product.id, product.serial, product.name ]
+      end
     end
-  end
 
-  def self.reset!
-    drop_table! && migrate!
-  end
-
-  private
-
-  def self.sample_data(size)
-    size.times do |i|
-      name = "Product #{i}"
-      serial = "P-D#{ i }"
-
-      Product.create!(name: name, serial: serial)
+    def reset!
+      drop_table! if connection.table_exists?(table_name)
+      migrate!
     end
-  end
 
-  def self.add_index(column_name, options = {})
-    connection.add_index table_name, column_name, options
-  end
+    def add_index(column_name, options = {})
+      printf "> Add index for [%s]\n" % [column_name].join(", ")
+      connection.add_index table_name, column_name, options
+    end
 
-  def self.drop_table!
-    connection.drop_table table_name
-  end
+    private
 
-  def self.reset!
-    drop_table! && migrate!
+    def sample_data(size)
+      size.times do |i|
+        name = "Product #{i}"
+        serial = "P-D#{ i }"
+
+        Product.create!(name: name, serial: serial)
+      end
+    end
+
+    def drop_table!
+      connection.drop_table table_name
+    end
   end
 end
 
@@ -55,15 +58,56 @@ end
 
 # Run the migration to create products table in product-database
 # NOTE: Turn me off after use
-#Product.migrate!
+Product.reset!
 
 # Display all data in products table
-#Product.display
+# Product.display
 
 # Explain the simple SQL query
-#puts Product.where(name: "Product 999").explain
-#
+# With timelog, we can see the difference in time consumed to execute the query.
+# It isn't accurate since the overhead time in ActiveRecord and Ruby, plus the magic caching
+# mechanism of ActiveRecord.
+puts Product.where(name: "Product 999").explain
+timelog { Product.where(name: "Product 999") }
+
 # Add index for name
 # Rerun same query and see the different
-#Product.add_index "name", unique: true
-#puts Product.where(name: "Product 999").explain
+Product.add_index "name", unique: true
+puts Product.where(name: "Product 999").explain
+timelog { Product.where(name: "Product 999") }
+
+# OR and IN operator
+timelog("use OR") { puts Product.where(name: "Product 999").or(Product.where(name: "Product 998")).explain }
+timelog("In a range of value") { puts Product.where(serial: ["Product 999", "Product 998"]).explain }
+
+# Experiment with multiple columns query
+#
+# Without an index for name
+timelog("name > serial") { Product.where(name: "Product 999", serial: "P-0999-0-1").explain }
+timelog("serial > name") { Product.where(serial: "P-0999-0-1", name: "Product 999").explain }
+
+# With no index
+Product.reset!
+
+timelog("name > serial") { Product.where(name: "Product 999", serial: "P-0999-0-1").explain }
+timelog("serial > name") { Product.where(serial: "P-0999-0-1", name: "Product 999").explain }
+
+
+# With Index for name and serial
+Product.reset!
+Product.add_index ["name", "serial"]
+
+puts Product.where(name: "Product 999", serial: "P-0999-0-1").explain
+timelog("name > serial") { puts Product.where(name: "Product 999", serial: "P-0999-0-1").explain }
+
+# Reverse order of serial and name column in where clause
+puts Product.where(serial: "P-0999-0-1", name: "Product 999").explain
+timelog("serial > name") { puts Product.where(serial: "P-0999-0-1", name: "Product 999").explain }
+
+# See if single column query can use multiple columns index
+timelog("single column name") { puts Product.where(name: "Product 999").explain }
+timelog("single column serial") { puts Product.where(serial: "P-0999-0-1").explain }
+
+# OR and IN operator
+timelog("use OR") { puts Product.where(name: "Product 999").or(Product.where(name: "Product 998")).explain }
+timelog("In a range of value") { puts Product.where(serial: ["Product 999", "Product 998"]).explain }

--- a/app.rb
+++ b/app.rb
@@ -53,5 +53,16 @@ end
 # This commands below is used to demonstrate the advantage of database index in Rails.
 
 # Run the migration to create products table in product-database
-Product.migrate!
-Product.display
+# NOTE: Turn me off after use
+#Product.migrate!
+
+# Display all data in products table
+#Product.display
+
+# Explain the simple SQL query
+#puts Product.where(name: "Product 999").explain
+#
+# Add index for name
+# Rerun same query and see the different
+#Product.add_index "name", unique: true
+#puts Product.where(name: "Product 999").explain

--- a/timelog.rb
+++ b/timelog.rb
@@ -1,0 +1,13 @@
+module Timelog
+  def timelog(message = nil, &block)
+    return unless block_given?
+
+    printf "%s\t" % [message] if message
+
+    start = Time.now
+    block.call
+    duration = Time.now - start
+
+    printf "Took %f seconds\n" % [ duration ]
+  end
+end


### PR DESCRIPTION
Add some more methods and start experiment with different kind of query against index.

The output of running `ruby app.rb` may look like this:

```
EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."name" = ? [["name", "Product 999"]]
0|0|0|SCAN TABLE products
Took 0.000290 seconds
> Add index for [name]
EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."name" = ? [["name", "Product 999"]]
0|0|0|SEARCH TABLE products USING INDEX index_products_on_name (name=?)
Took 0.000199 seconds
use OR  EXPLAIN for: SELECT "products".* FROM "products" WHERE ("products"."name" = ? OR "products"."name" = ?) [["name", "Product 999"], ["name", "Product 998"]]
0|0|0|SEARCH TABLE products USING INDEX index_products_on_name (name=?)
0|0|0|EXECUTE LIST SUBQUERY 1
Took 0.002029 seconds
In a range of value     EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."serial" IN (?, ?) [["serial", "Product 999"], ["serial", "Product 998"]]
0|0|0|SCAN TABLE products
Took 0.002354 seconds
There is only index for name, not for serial column
name > serial   Took 0.001837 seconds
serial > name   Took 0.002013 seconds
There is no index
name > serial   Took 0.001964 seconds
serial > name   Took 0.001623 seconds
> Add index for [name, serial]
EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."name" = ? AND "products"."serial" = ? [["name", "Product 999"], ["serial", "P-0999-0-1"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=? AND serial=?)
name > serial   EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."name" = ? AND "products"."serial" = ? [["name", "Product 999"], ["serial", "P-0999-0-1"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=? AND serial=?)
Took 0.001182 seconds
EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."serial" = ? AND "products"."name" = ? [["serial", "P-0999-0-1"], ["name", "Product 999"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=? AND serial=?)
serial > name   EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."serial" = ? AND "products"."name" = ? [["serial", "P-0999-0-1"], ["name", "Product 999"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=? AND serial=?)
Took 0.001265 seconds
single column name      EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."name" = ? [["name", "Product 999"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=?)
Took 0.001280 seconds
single column serial    EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."serial" = ? [["serial", "P-0999-0-1"]]
0|0|0|SCAN TABLE products
Took 0.001449 seconds
use OR  EXPLAIN for: SELECT "products".* FROM "products" WHERE ("products"."name" = ? OR "products"."name" = ?) [["name", "Product 999"], ["name", "Product 998"]]
0|0|0|SEARCH TABLE products USING COVERING INDEX index_products_on_name_and_serial (name=?)
0|0|0|EXECUTE LIST SUBQUERY 1
Took 0.001880 seconds
In a range of value     EXPLAIN for: SELECT "products".* FROM "products" WHERE "products"."serial" IN (?, ?) [["serial", "Product 999"], ["serial", "Product 998"]]
0|0|0|SCAN TABLE products
Took 0.001714 seconds

```